### PR TITLE
Fix /random pushing new history entry

### DIFF
--- a/src/app/components/homepage/homepage.component.ts
+++ b/src/app/components/homepage/homepage.component.ts
@@ -84,7 +84,7 @@ export class HomepageComponent implements OnInit, OnDestroy, AfterViewInit {
       this.colorFilterService.emitFilterColor(null);
       const randomPalette = this.getRandomPaletteId();
 
-      this.router.navigateByUrl('/' + randomPalette).then(() => {
+      this.router.navigateByUrl('/' + randomPalette, { replaceUrl: true }).then(() => {
         this.titleService.setTitle(randomPalette + ' color palette | colors.lol');
       });
     } else if (title && !this.isPaletteFound()) {


### PR DESCRIPTION
Pushing new history entry will make visitor unable to go back via browser back button because the they will encounter /random and another new entry will be pushed to the stack

Passing `replaceUrl: true` to `navigateByUrl` fixes this.

p.s. this is in reference to someone complaining in HN: https://news.ycombinator.com/item?id=30485139 